### PR TITLE
GitHub Action to automatically create a PR to main

### DIFF
--- a/.github/workflows/docs-auto-pr.yml
+++ b/.github/workflows/docs-auto-pr.yml
@@ -1,0 +1,22 @@
+name: Create a docs PR
+
+on:
+  push:
+    branches: [ '*docs' ]
+
+jobs:
+  createPullRequest:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v3
+
+      - name: Create Pull Request
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: "${{ github.ref_name }}"                             # If blank, default: triggered branch
+          destination_branch: "master"                                        # If blank, default: master
+          pr_title: 'Updating ${{ github.ref_name }} automatically'           # Title of pull request
+          pr_body: "*An automated PR to update ${{ github.ref_name }}*"       # Full markdown support, requires pr_title to be set
+          pr_allow_empty: false                                               # Creates pull request even if there are no changes
+          github_token: ${{ secrets.API_TOKEN_GITHUB }}

--- a/.github/workflows/docs-auto-pr.yml
+++ b/.github/workflows/docs-auto-pr.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           source_branch: "${{ github.ref_name }}"                             # If blank, default: triggered branch
           destination_branch: "master"                                        # If blank, default: master
-          pr_title: 'Updating ${{ github.ref_name }} automatically'           # Title of pull request
+          pr_title: '[DOCS] Updating ${{ github.ref_name }} automatically'           # Title of pull request
           pr_body: "*An automated PR to update ${{ github.ref_name }}*"       # Full markdown support, requires pr_title to be set
           pr_allow_empty: false                                               # Creates pull request even if there are no changes
           github_token: ${{ secrets.API_TOKEN_GITHUB }}


### PR DESCRIPTION
## Description

GitHub Action to automatically create a PR when `*-docs` branches are updated by the component's own GA. E.g. gateway repo GA will push changes in docs to `gateway-docs` branch in this repo, which will create a PR for revision.

## Is this PR related with an open issue?

Related to Issue [engineering #51](https://github.com/keyko-io/engineering/issues/51)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [x] Documentation

